### PR TITLE
Fix setup error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,8 @@
+import builtins
+
+builtins.__SOYDATA_SETUP__ = True
+
+
 import soydata
 from setuptools import setup, find_packages
 

--- a/soydata/__init__.py
+++ b/soydata/__init__.py
@@ -1,5 +1,18 @@
-__author__ = 'lovit'
-__version__ = '0.1.0'
+import sys
 
-from . import data
-from . import visualize
+__author__ = "lovit"
+__version__ = "0.1.0"
+
+
+try:
+    __SOYDATA_SETUP__
+except NameError:
+    __SOYDATA_SETUP__ = False
+
+
+if __SOYDATA_SETUP__:
+    sys.stderr.write("Running in setup\n")
+
+else:
+    from . import data
+    from . import visualize


### PR DESCRIPTION
## 문제점
1. 설치 시 [setup.py](https://github.com/lovit/synthetic_dataset/blob/2518aeea2db03852a997e1ab807c59218ebd634d/setup.py) 에서 [import soydata](https://github.com/lovit/synthetic_dataset/blob/2518aeea2db03852a997e1ab807c59218ebd634d/setup.py#L1C12-L1C12) 를 하는데 이때 내부에서 numpy 등 타 모듈을 import 합니다
2. [install_requires](https://github.com/lovit/synthetic_dataset/blob/2518aeea2db03852a997e1ab807c59218ebd634d/setup.py#L16C5-L16C21) 를 참조하여 설치를 하기 전에 이미 import 에서 실패를 합니다.
3. 따라서 설치 시 이미 `install_requires` 를 충족한 환경에서만 설치가 가능합니다

## 해결
- `setup.py` 에서 `import soydata`  를 하는 상황에서는 일부만 import 를 합니다
- 아래 두 방식을 참고했습니다.
  - [numpy](https://github.com/search?q=repo%3Anumpy%2Fnumpy%20__NUMPY_SETUP__&type=code)
  - [sklearn](https://github.com/search?q=repo%3Ascikit-learn%2Fscikit-learn%20__SKLEARN_SETUP__&type=code)

